### PR TITLE
Fix Railway deployment

### DIFF
--- a/server.py
+++ b/server.py
@@ -522,9 +522,9 @@ import os
 # Determine port and get the FastAPI app for deployment
 port = int(os.getenv("PORT", 8000))
 
-# For FastMCP 2.x, we need to run the server differently
-# The mcp instance itself can be run as an ASGI app
-app = mcp
+# For FastMCP 2.x we expose a Starlette app
+# using the FastMCP http_app helper
+app = mcp.http_app()
 
 if __name__ == "__main__":
     print(f"Running MCP locally on port {port}")


### PR DESCRIPTION
## Summary
- expose FastMCP as a proper ASGI app using `mcp.http_app()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686045d8c8cc832bac3a3a201f5cbd73